### PR TITLE
Blockingcommand

### DIFF
--- a/src/main/java/org/kontalk/client/BlockingCommand.java
+++ b/src/main/java/org/kontalk/client/BlockingCommand.java
@@ -20,6 +20,7 @@ package org.kontalk.client;
 
 import java.util.LinkedList;
 import java.util.List;
+
 import org.jivesoftware.smack.packet.IQ;
 import org.jivesoftware.smack.provider.IQProvider;
 import org.xmlpull.v1.XmlPullParser;
@@ -124,7 +125,6 @@ public class BlockingCommand extends IQ {
 
         @Override
         public IQ parseIQ(XmlPullParser parser) throws Exception {
-            System.out.println("parsing...");
             List<String> jidList = null;
             boolean in_blocklist = false, done = false;
 
@@ -147,7 +147,6 @@ public class BlockingCommand extends IQ {
                     }
                     else if (in_blocklist && "item".equals(parser.getName())) {
                         String jid = parser.getAttributeValue(null, "jid");
-                        System.out.println("jid: "+jid);
                         if (jid != null && jid.length() > 0) {
                             if (jidList == null)
                                 jidList = new LinkedList<String>();


### PR DESCRIPTION
the parser is already set to the start of the "blocklist" tag so this needs to be checked first before calling next()
