### PR TITLE
Bump to Smack 4.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 ext {
-    smackVersion = '4.1.2'
+    smackVersion = '4.1.3'
 }
 
 checkstyle {


### PR DESCRIPTION
I've release Smack 4.1.3 yesterday, which includes a mem leak fix.

Remember to also bump the git submodules of client-common in androidclient and desktopclient